### PR TITLE
chore: promote postegres to version 0.0.2

### DIFF
--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -4,5 +4,6 @@ helmfiles:
 - path: helmfiles/kuberhealthy/helmfile.yaml
 - path: helmfiles/myjenkins/helmfile.yaml
 - path: helmfiles/tekton-pipelines/helmfile.yaml
+- path: helmfiles/jx-production/helmfile.yaml
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -1,0 +1,11 @@
+filepath: ""
+namespace: jx-production
+repositories:
+- name: dev
+  url: https://hazem-internship.github.io/gow-new-1/
+releases:
+- chart: dev/postegres
+  version: 0.0.2
+  name: postegres
+templates: {}
+renderedvalues: {}


### PR DESCRIPTION
this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge

-----
# postegres

## Changes in version 0.0.2

### Chores

* release 0.0.2 (jenkins-x-bot)
* add variables (jenkins-x-bot)
