### PR TITLE
chore: promote projet-cd to version 0.0.2

### DIFF
--- a/config-root/namespaces/jx-staging/projet-cd/projet-cd-ingress.yaml
+++ b/config-root/namespaces/jx-staging/projet-cd/projet-cd-ingress.yaml
@@ -1,0 +1,22 @@
+# Source: projet-cd/templates/ingress.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    meta.helm.sh/release-name: 'projet-cd'
+  name: projet-cd
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+  - http:
+      paths:
+      - pathType: ImplementationSpecific
+        backend:
+          service:
+            name: projet-cd
+            port:
+              number: 80
+    host: projet-cd-jx-staging.10.0.0.100.nip.io

--- a/config-root/namespaces/jx-staging/projet-cd/projet-cd-projet-cd-deploy.yaml
+++ b/config-root/namespaces/jx-staging/projet-cd/projet-cd-projet-cd-deploy.yaml
@@ -1,0 +1,61 @@
+# Source: projet-cd/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: projet-cd-projet-cd
+  labels:
+    draft: draft-app
+    chart: "projet-cd-0.0.2"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'projet-cd'
+    wave.pusher.com/update-on-config-change: 'true'
+  namespace: jx-staging
+spec:
+  selector:
+    matchLabels:
+      app: projet-cd-projet-cd
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: projet-cd-projet-cd
+    spec:
+      serviceAccountName: projet-cd-projet-cd
+      containers:
+      - name: projet-cd
+        image: "ghcr.io/hazem-internship/projet-cd:0.0.2"
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: VERSION
+          value: 0.0.2
+        envFrom: null
+        ports:
+        - name: http
+          containerPort: 8080
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 400m
+            memory: 256Mi
+          requests:
+            cpu: 200m
+            memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:
+      - name: "tekton-container-registry-auth"

--- a/config-root/namespaces/jx-staging/projet-cd/projet-cd-projet-cd-sa.yaml
+++ b/config-root/namespaces/jx-staging/projet-cd/projet-cd-projet-cd-sa.yaml
@@ -1,0 +1,10 @@
+# Source: projet-cd/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: projet-cd-projet-cd
+  annotations:
+    meta.helm.sh/release-name: 'projet-cd'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-staging/projet-cd/projet-cd-svc.yaml
+++ b/config-root/namespaces/jx-staging/projet-cd/projet-cd-svc.yaml
@@ -1,0 +1,20 @@
+# Source: projet-cd/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: projet-cd
+  labels:
+    chart: "projet-cd-0.0.2"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'projet-cd'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    targetPort: 8080
+    protocol: TCP
+    name: http
+  selector:
+    app: projet-cd-projet-cd

--- a/config-root/namespaces/myjenkins/jenkins/templates/tests/jenkins-ui-test-ttwa9-pod.yaml
+++ b/config-root/namespaces/myjenkins/jenkins/templates/tests/jenkins-ui-test-ttwa9-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "jenkins-ui-test-hevwg"
+  name: "jenkins-ui-test-ttwa9"
   namespace: myjenkins
   annotations:
     "helm.sh/hook": test-success

--- a/docs/README.md
+++ b/docs/README.md
@@ -108,6 +108,16 @@
 	      <td></td>
 	      <td></td>
 	    </tr>
+    <tr>
+		      <td colspan='5'><h3>jx-staging</h3></td>
+		    </tr>
+	    <tr>
+	      <td>projet-cd</td>
+	      <td title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> projet-cd</td>
+	      <td>0.0.2</td>
+	      <td></td>
+	      <td></td>
+	    </tr>
 
   </tbody>
 </table>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -235,3 +235,16 @@
     version: 0.5.0
 - namespace: jx-staging
   path: helmfiles/jx-staging/helmfile.yaml
+  releases:
+  - apiVersion: v1
+    appVersion: 0.0.2
+    description: A Helm chart for Kubernetes
+    firstDeployed: "2023-03-07T13:41:44Z"
+    icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
+    lastDeployed: "2023-03-07T13:41:44Z"
+    name: projet-cd
+    releaseName: projet-cd
+    repositoryName: dev
+    repositoryUrl: https://hazem-internship.github.io/gow-new-1/
+    resourcePath: config-root/namespaces/jx-staging/projet-cd
+    version: 0.0.2

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -11,5 +11,7 @@ releases:
 - chart: dev/projet-cd
   version: 0.0.2
   name: projet-cd
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -7,5 +7,9 @@ namespace: jx-staging
 repositories:
 - name: dev
   url: https://hazem-internship.github.io/gow-new-1/
+releases:
+- chart: dev/projet-cd
+  version: 0.0.2
+  name: projet-cd
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge

-----
# projet-cd

## Changes in version 0.0.2

### Chores

* release 0.0.2 (jenkins-x-bot)
* add variables (jenkins-x-bot)

### Other Changes

These commits did not use [Conventional Commits](https://conventionalcommits.org/) formatted messages:

* Update release.yaml (hazemTa)
