### PR TITLE
chore: promote projet-cd to version 0.0.5

### DIFF
--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: https://hazem-internship.github.io/gow-new-1/
 releases:
 - chart: dev/projet-cd
-  version: 0.0.2
+  version: 0.0.5
   name: projet-cd
   values:
   - jx-values.yaml


### PR DESCRIPTION
this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge

-----
# projet-cd

## Changes in version 0.0.5

### Chores

* release 0.0.5 (jenkins-x-bot)
* add variables (jenkins-x-bot)

### Other Changes

These commits did not use [Conventional Commits](https://conventionalcommits.org/) formatted messages:

* Update Dockerfile (hazemTa)
