### PR TITLE
chore: promote projet-cd to version 0.0.7

### DIFF
--- a/config-root/namespaces/jx-staging/projet-cd/projet-cd-projet-cd-deploy.yaml
+++ b/config-root/namespaces/jx-staging/projet-cd/projet-cd-projet-cd-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: projet-cd-projet-cd
   labels:
     draft: draft-app
-    chart: "projet-cd-0.0.3"
+    chart: "projet-cd-0.0.7"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'projet-cd'
@@ -25,11 +25,11 @@ spec:
       serviceAccountName: projet-cd-projet-cd
       containers:
       - name: projet-cd
-        image: "ghcr.io/hazem-internship/projet-cd:0.0.3"
+        image: "ghcr.io/hazem-internship/projet-cd:0.0.7"
         imagePullPolicy: IfNotPresent
         env:
         - name: VERSION
-          value: 0.0.3
+          value: 0.0.7
         envFrom: null
         ports:
         - name: http

--- a/config-root/namespaces/jx-staging/projet-cd/projet-cd-svc.yaml
+++ b/config-root/namespaces/jx-staging/projet-cd/projet-cd-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: projet-cd
   labels:
-    chart: "projet-cd-0.0.3"
+    chart: "projet-cd-0.0.7"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'projet-cd'

--- a/config-root/namespaces/myjenkins/jenkins/templates/tests/jenkins-ui-test-ecdpd-pod.yaml
+++ b/config-root/namespaces/myjenkins/jenkins/templates/tests/jenkins-ui-test-ecdpd-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "jenkins-ui-test-2hdal"
+  name: "jenkins-ui-test-ecdpd"
   namespace: myjenkins
   annotations:
     "helm.sh/hook": test-success

--- a/docs/README.md
+++ b/docs/README.md
@@ -114,7 +114,7 @@
 	    <tr>
 	      <td>projet-cd</td>
 	      <td title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> projet-cd</td>
-	      <td>0.0.3</td>
+	      <td>0.0.7</td>
 	      <td></td>
 	      <td></td>
 	    </tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -237,17 +237,17 @@
   path: helmfiles/jx-staging/helmfile.yaml
   releases:
   - apiVersion: v1
-    appVersion: 0.0.3
+    appVersion: 0.0.7
     description: A Helm chart for Kubernetes
-    firstDeployed: "2023-03-07T14:42:33Z"
+    firstDeployed: "2023-03-08T14:11:50Z"
     icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
-    lastDeployed: "2023-03-07T14:42:33Z"
+    lastDeployed: "2023-03-08T14:11:50Z"
     name: projet-cd
     releaseName: projet-cd
     repositoryName: dev
     repositoryUrl: https://hazem-internship.github.io/gow-new-1/
     resourcePath: config-root/namespaces/jx-staging/projet-cd
-    version: 0.0.3
+    version: 0.0.7
 - namespace: jx-production
   path: helmfiles/jx-production/helmfile.yaml
   releases:

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: https://hazem-internship.github.io/gow-new-1/
 releases:
 - chart: dev/projet-cd
-  version: 0.0.3
+  version: 0.0.7
   name: projet-cd
   values:
   - jx-values.yaml


### PR DESCRIPTION
this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge

-----
# projet-cd

## Changes in version 0.0.7

### Chores

* release 0.0.7 (jenkins-x-bot)
* add variables (jenkins-x-bot)
