### PR TITLE
chore: promote projet-cd to version 0.0.14

### DIFF
--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -7,5 +7,9 @@ namespace: jx-production
 repositories:
 - name: dev
   url: https://hazem-internship.github.io/gow-new-1/
+releases:
+- chart: dev/projet-cd
+  version: 0.0.14
+  name: projet-cd
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge

-----
# projet-cd

## Changes in version 0.0.14

### Chores

* release 0.0.14 (jenkins-x-bot)
* add variables (jenkins-x-bot)

### Other Changes

These commits did not use [Conventional Commits](https://conventionalcommits.org/) formatted messages:

* Update release.yaml (hazemTa)
